### PR TITLE
chore: begin removing @ts-nocheck — type DiceRoller, LineOfSight, Spell, Character (+ bug fixes)

### DIFF
--- a/src/contexts/reducers/combatReducer.ts
+++ b/src/contexts/reducers/combatReducer.ts
@@ -242,7 +242,7 @@ export function combatReducer(
         // Award XP immutably
         const xp = state.combat.calculateXPReward();
         const character = Character.fromJSON(state.playerCharacter.toJSON());
-        character.gainXP(xp);
+        character.awardXP(xp);
         updates.playerCharacter = character;
       }
 

--- a/src/contexts/reducers/explorationReducer.ts
+++ b/src/contexts/reducers/explorationReducer.ts
@@ -129,7 +129,7 @@ export function explorationReducer(
       // Award XP — immutably
       if (xp && state.playerCharacter) {
         const character = Character.fromJSON(state.playerCharacter.toJSON());
-        character.gainXP(xp);
+        character.awardXP(xp);
         newState.playerCharacter = character;
       }
 

--- a/src/contexts/reducers/inventoryReducer.ts
+++ b/src/contexts/reducers/inventoryReducer.ts
@@ -15,6 +15,7 @@
 import { Character } from '../../game/Character';
 import { advanceTime } from '../../game/TimeManager';
 import { TIME } from '../../constants/gameConstants';
+import logger from '../../utils/logger';
 import type { GameState, Action } from '../../types/state';
 
 export function inventoryReducer(

--- a/src/contexts/reducers/inventoryReducer.ts
+++ b/src/contexts/reducers/inventoryReducer.ts
@@ -7,9 +7,7 @@
  * - EQUIP_ITEM
  * - UNEQUIP_ITEM
  * - CONSUME_RATIONS
- * - CONSUME_WATER
  * - FORAGE
- * - FIND_WATER
  */
 
 import { Character } from '../../game/Character';
@@ -73,7 +71,7 @@ export function inventoryReducer(
         return state;
       }
 
-      const slot = payloadSlot || item.slot;
+      const slot = (payloadSlot || item.slot) as keyof typeof character.equipment;
 
       // Remove from inventory
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -97,9 +95,10 @@ export function inventoryReducer(
       if (!state.playerCharacter) return state;
 
       const character = Character.fromJSON(state.playerCharacter.toJSON());
-      const item = character.equipment[slot];
+      const equipSlot = slot as keyof typeof character.equipment;
+      const item = character.equipment[equipSlot];
       if (item) {
-        delete character.equipment[slot];
+        character.equipment[equipSlot] = null;
         character.inventory.push(item);
       }
 
@@ -123,38 +122,11 @@ export function inventoryReducer(
       };
     }
 
-    case ACTIONS.CONSUME_WATER: {
-      const { amount } = action.payload;
-
-      if (!state.playerCharacter) return state;
-
-      const character = Character.fromJSON(state.playerCharacter.toJSON());
-      character.water = Math.max(0, character.water - amount);
-
-      return {
-        ...state,
-        playerCharacter: character,
-      };
-    }
-
     case ACTIONS.FORAGE: {
       const { character } = action.payload;
 
       // Advance time
       const newGameTime = advanceTime(state.gameTime, TIME.FORAGE_TIME_MINUTES);
-
-      return {
-        ...state,
-        playerCharacter: character,
-        gameTime: newGameTime,
-      };
-    }
-
-    case ACTIONS.FIND_WATER: {
-      const { character } = action.payload;
-
-      // Advance time
-      const newGameTime = advanceTime(state.gameTime, TIME.SEARCH_TIME_MINUTES);
 
       return {
         ...state,

--- a/src/contexts/reducers/questReducer.ts
+++ b/src/contexts/reducers/questReducer.ts
@@ -61,7 +61,7 @@ export function questReducer(
           character.gold += quest.rewards.gold;
         }
         if (quest.rewards.xp) {
-          character.gainXP(quest.rewards.xp);
+          character.awardXP(quest.rewards.xp);
         }
         updatedCharacter = character;
       }

--- a/src/game/Character.ts
+++ b/src/game/Character.ts
@@ -1,14 +1,109 @@
-// @ts-nocheck
-// TODO: Add proper types - large D&D 5e Character class (~1093 lines)
+// Character — D&D 5e player/NPC character model
 import { GAME_DEFAULTS, DND, XP_TABLE } from '../constants/gameConstants';
 import logger from '../utils/logger';
-import { Item } from './Item';
+import { Item, type ItemConfig, type ItemJSON } from './Item';
+
+type AbilityName =
+  | 'strength'
+  | 'dexterity'
+  | 'constitution'
+  | 'intelligence'
+  | 'wisdom'
+  | 'charisma';
+
+type AbilityScores = Record<AbilityName, number>;
+
+type EquipmentSlot =
+  | 'head'
+  | 'neck'
+  | 'chest'
+  | 'hands'
+  | 'legs'
+  | 'feet'
+  | 'ring1'
+  | 'ring2'
+  | 'mainHand'
+  | 'offHand';
+
+type Equipment = Record<EquipmentSlot, Item | null>;
+
+interface ClassFeature {
+  name: string;
+  uses?: number;
+  maxUses?: number;
+  actionType?: string;
+  restType?: string;
+  description?: string;
+}
+
+interface HiddenStats {
+  piety: number;
+  generosity: number;
+}
+
+interface BaseStats {
+  armorClass: number;
+  abilities: AbilityScores;
+  maxHP: number;
+}
+
+interface ClassConfig {
+  hitDie: string;
+  abilities: AbilityScores;
+  armorClass: number;
+  proficiencies: string[];
+  abilities_list: ClassFeature[];
+}
+
+interface LevelUpResult {
+  oldLevel: number;
+  newLevel: number;
+  hpGain: number;
+  proficiencyBonus: number;
+  newMaxHP: number;
+  newFeatures: ClassFeature[];
+}
 
 /**
  * Character class representing player and NPC characters in D&D 5e
  */
 export class Character {
-  constructor(name, charClass) {
+  name: string;
+  class: string | null;
+  level: number;
+  abilities: AbilityScores;
+  maxHP: number;
+  currentHP: number;
+  armorClass: number;
+  proficiencyBonus: number;
+  initiativeBonus: number;
+  moveDistance: number;
+  viewDistance: number;
+  hitDie: string;
+  proficiencies: string[];
+  spells: unknown[];
+  abilities_list: ClassFeature[];
+  equipment: Equipment;
+  inventory: Item[];
+  gold: number;
+  personality: string | null;
+  background: string | null;
+  gender: string | null;
+  hitDiceRemaining: number;
+  lastLongRest: number;
+  spellSlotsUsed: Record<number, number>;
+  knownSpells: unknown[];
+  preparedSpells: unknown[];
+  rations: number;
+  daysWithoutFood: number;
+  exhaustionLevel: number;
+  foragedHexes: Record<string, number>;
+  xp: number;
+  xpToNextLevel: number;
+  hiddenStats: HiddenStats;
+  baseStats?: BaseStats;
+
+  constructor(name: string, charClass: string | null) {
     this.name = name;
     this.class = charClass;
     this.level = 1;
@@ -104,7 +199,7 @@ export class Character {
    * D&D 5e XP Progression Table
    * Maps level to XP required to reach that level
    */
-  static XP_TABLE = {
+  static XP_TABLE: Record<number, number> = {
     1: 0,
     2: 300,
     3: 900,
@@ -130,50 +225,50 @@ export class Character {
   /**
    * Get XP required to reach a specific level
    */
-  static getXPForLevel(level) {
+  static getXPForLevel(level: number): number {
     if (level < 1) return 0;
     if (level > 20) return Character.XP_TABLE[20];
     return Character.XP_TABLE[level] || 0;
   }
 
-  awardXP(amount) {
+  awardXP(amount: number): boolean {
     if (typeof amount !== 'number' || amount < 0) return false;
     this.xp += amount;
     return this.shouldLevelUp();
   }
 
-  shouldLevelUp() {
+  shouldLevelUp(): boolean {
     if (this.level >= XP_TABLE.length) return false; // Max level
     return this.xp >= this.xpToNextLevel;
   }
 
-  addGold(amount) {
+  addGold(amount: number): boolean {
     if (typeof amount !== 'number' || amount < 0) return false;
     this.gold += amount;
     return true;
   }
 
-  removeGold(amount) {
+  removeGold(amount: number): boolean {
     if (typeof amount !== 'number' || amount < 0) return false;
     if (this.gold < amount) return false;
     this.gold -= amount;
     return true;
   }
 
-  addItem(item) {
+  addItem(item: Item | null): boolean {
     if (!item) return false;
     this.inventory.push(item);
     return true;
   }
 
-  removeItem(itemId) {
+  removeItem(itemId: string): Item | null {
     const index = this.inventory.findIndex(item => item.id === itemId);
     if (index === -1) return null;
     const removed = this.inventory.splice(index, 1)[0];
     return removed;
   }
 
-  equipItem(itemId, slot = null) {
+  equipItem(itemId: string, slot: EquipmentSlot | null = null): boolean {
     const item = this.inventory.find(i => i.id === itemId);
     if (!item) {
       logger.items.warn('Item not found in inventory', { itemId, character: this.name });
@@ -185,7 +280,7 @@ export class Character {
       return false;
     }
 
-    const targetSlot = slot || item.slot;
+    const targetSlot = (slot || item.slot) as EquipmentSlot;
     if (!targetSlot) {
       logger.items.warn('No slot specified for item', { item: item.name, character: this.name });
       return false;
@@ -223,7 +318,7 @@ export class Character {
     return true;
   }
 
-  unequipItem(slot) {
+  unequipItem(slot: EquipmentSlot): boolean {
     if (!this.equipment[slot]) {
       logger.items.warn('No item equipped in slot', { slot, character: this.name });
       return false;
@@ -236,21 +331,22 @@ export class Character {
     return true;
   }
 
-  getEquippedItems() {
-    const equipped = {};
-    Object.keys(this.equipment).forEach(slot => {
-      if (this.equipment[slot]) {
-        equipped[slot] = this.equipment[slot];
+  getEquippedItems(): Partial<Record<EquipmentSlot, Item>> {
+    const equipped: Partial<Record<EquipmentSlot, Item>> = {};
+    (Object.keys(this.equipment) as EquipmentSlot[]).forEach(slot => {
+      const item = this.equipment[slot];
+      if (item) {
+        equipped[slot] = item;
       }
     });
     return equipped;
   }
 
-  getInventoryItems() {
+  getInventoryItems(): Item[] {
     return [...this.inventory];
   }
 
-  calculateEffectiveStats() {
+  calculateEffectiveStats(): void {
     if (!this.baseStats) {
       this.baseStats = {
         armorClass: this.armorClass,
@@ -258,13 +354,23 @@ export class Character {
         maxHP: this.maxHP,
       };
     }
+    const base = this.baseStats;
 
-    this.armorClass = this.baseStats.armorClass;
-    this.maxHP = this.baseStats.maxHP;
+    this.armorClass = base.armorClass;
+    this.maxHP = base.maxHP;
     this.initiativeBonus = 0;
-    Object.keys(this.abilities).forEach(ability => {
-      this.abilities[ability] = this.baseStats.abilities[ability];
+    (Object.keys(this.abilities) as AbilityName[]).forEach(ability => {
+      this.abilities[ability] = base.abilities[ability];
     });
+
+    const abilityMap: Record<string, AbilityName> = {
+      str: 'strength',
+      dex: 'dexterity',
+      con: 'constitution',
+      int: 'intelligence',
+      wis: 'wisdom',
+      cha: 'charisma',
+    };
 
     Object.values(this.equipment).forEach(item => {
       if (item && item.effects) {
@@ -272,15 +378,7 @@ export class Character {
           this.armorClass += item.effects.ac;
         }
 
-        ['str', 'dex', 'con', 'int', 'wis', 'cha'].forEach(ability => {
-          const abilityMap = {
-            str: 'strength',
-            dex: 'dexterity',
-            con: 'constitution',
-            int: 'intelligence',
-            wis: 'wisdom',
-            cha: 'charisma',
-          };
+        (['str', 'dex', 'con', 'int', 'wis', 'cha'] as const).forEach(ability => {
           const fullAbilityName = abilityMap[ability];
           if (item.effects[ability]) {
             this.abilities[fullAbilityName] += item.effects[ability];
@@ -299,7 +397,7 @@ export class Character {
     });
   }
 
-  getTotalWeight() {
+  getTotalWeight(): number {
     let weight = 0;
     this.inventory.forEach(item => {
       weight += item.weight || 0;
@@ -312,10 +410,10 @@ export class Character {
     return weight;
   }
 
-  applyClassModifiers(charClass) {
+  applyClassModifiers(charClass: string): void {
     const classKey = charClass.toLowerCase();
 
-    const classConfigs = {
+    const classConfigs: Record<string, ClassConfig> = {
       barbarian: {
         hitDie: 'd12',
         abilities: {
@@ -604,7 +702,7 @@ export class Character {
     this.hitDie = config.hitDie;
     this.abilities = { ...config.abilities };
 
-    const hitDieValue = parseInt(config.hitDie.substring(1));
+    const hitDieValue = parseInt(config.hitDie.substring(1), 10);
     this.maxHP = hitDieValue + this.getModifier('constitution');
     this.currentHP = this.maxHP;
 
@@ -622,12 +720,12 @@ export class Character {
    * they are granted, not purchased. calculateEffectiveStats() is called once at the
    * end so any item effects (e.g. AC from armor) are applied correctly.
    */
-  applyStartingLoadout(charClass) {
+  applyStartingLoadout(charClass: string): void {
     const cls = (charClass || '').toLowerCase();
 
     // Use Item factory methods so equipment slots hold proper Item instances
     // with all class methods (getRarityColor, isEquippable, etc.) intact.
-    const W = (name, damage, damageType, opts = {}) =>
+    const W = (name: string, damage: string, damageType: string, opts: ItemConfig = {}) =>
       Item.createWeapon(name, damage, damageType, {
         description: `Starting ${name}.`,
         value: 0,
@@ -635,7 +733,7 @@ export class Character {
         ...opts,
       });
 
-    const A = (name, acType, slot = 'chest') =>
+    const A = (name: string, acType: string, slot = 'chest') =>
       Item.createArmor(name, 0, acType, {
         // AC is already baked into armorClass via applyClassModifiers — effects.ac = 0
         // avoids double-counting when calculateEffectiveStats runs.
@@ -645,7 +743,7 @@ export class Character {
         slot,
       });
 
-    const shield = () =>
+    const shield = (): Item =>
       Item.createArmor('Shield', 0, 'shield', {
         description: 'A sturdy wooden shield.',
         value: 0,
@@ -774,25 +872,25 @@ export class Character {
     };
   }
 
-  getModifier(ability) {
+  getModifier(ability: AbilityName): number {
     const score = this.abilities[ability];
     return Math.floor((score - GAME_DEFAULTS.ABILITY_SCORE) / 2);
   }
 
-  takeDamage(amount) {
+  takeDamage(amount: number): boolean {
     this.currentHP = Math.max(0, this.currentHP - amount);
     return this.currentHP === 0;
   }
 
-  damage(amount) {
+  damage(amount: number): boolean {
     return this.takeDamage(amount);
   }
 
-  heal(amount) {
+  heal(amount: number): void {
     this.currentHP = Math.min(this.maxHP, this.currentHP + amount);
   }
 
-  levelUp() {
+  levelUp(): LevelUpResult | null {
     if (this.level >= 20) {
       logger.general.warn('Character is already max level', { character: this.name, level: 20 });
       return null;
@@ -803,7 +901,7 @@ export class Character {
     this.proficiencyBonus =
       DND.PROFICIENCY_BONUS[this.level - 1] || GAME_DEFAULTS.PROFICIENCY_BONUS;
 
-    const hitDieValue = parseInt(this.hitDie.substring(1));
+    const hitDieValue = parseInt(this.hitDie.substring(1), 10);
     const hpGain = Math.floor(hitDieValue / 2) + 1 + this.getModifier('constitution');
     this.maxHP += hpGain;
     this.currentHP += hpGain;
@@ -834,9 +932,9 @@ export class Character {
    * Returns class features gained at a specific level.
    * Called by levelUp() to grant features automatically.
    */
-  _getClassFeaturesForLevel(charClass, level) {
+  _getClassFeaturesForLevel(charClass: string | null, level: number): ClassFeature[] {
     const cls = (charClass || '').toLowerCase();
-    const features = [];
+    const features: ClassFeature[] = [];
 
     if (cls === 'barbarian') {
       if (level === 2) {
@@ -880,14 +978,14 @@ export class Character {
     return features;
   }
 
-  useHitDice(count) {
+  useHitDice(count: number): number {
     const diceToUse = Math.min(count, this.hitDiceRemaining);
     this.hitDiceRemaining -= diceToUse;
     return diceToUse;
   }
 
-  getAttacksPerAction() {
-    const classKey = this.class.toLowerCase();
+  getAttacksPerAction(): number {
+    const classKey = (this.class || '').toLowerCase();
 
     if (classKey === 'fighter') {
       if (this.level >= 20) return 4;
@@ -903,16 +1001,17 @@ export class Character {
     return 1;
   }
 
-  hasAbility(abilityName) {
+  hasAbility(abilityName: string): boolean {
     return this.abilities_list.some(
       ability => ability.name.toLowerCase() === abilityName.toLowerCase()
     );
   }
 
-  getAvailableBonusActions() {
-    const bonusActions = [];
+  getAvailableBonusActions(): ClassFeature[] {
+    const bonusActions: ClassFeature[] = [];
+    const classKey = (this.class || '').toLowerCase();
 
-    if (this.class.toLowerCase() === 'rogue' && this.level >= 2) {
+    if (classKey === 'rogue' && this.level >= 2) {
       bonusActions.push({
         name: 'Cunning Action',
         actionType: 'bonusAction',
@@ -922,7 +1021,7 @@ export class Character {
       });
     }
 
-    if (this.class.toLowerCase() === 'monk') {
+    if (classKey === 'monk') {
       bonusActions.push({
         name: 'Martial Arts',
         actionType: 'bonusAction',
@@ -932,9 +1031,9 @@ export class Character {
       });
     }
 
-    if (this.class.toLowerCase() === 'barbarian') {
+    if (classKey === 'barbarian') {
       const rageAbility = this.abilities_list.find(a => a.name === 'Rage');
-      if (rageAbility && rageAbility.uses > 0) {
+      if (rageAbility && (rageAbility.uses ?? 0) > 0) {
         bonusActions.push({
           ...rageAbility,
           actionType: 'bonusAction',
@@ -945,29 +1044,29 @@ export class Character {
     const customBonusActions = this.abilities_list.filter(
       ability =>
         ability.actionType === 'bonusAction' &&
-        (!ability.maxUses || ability.maxUses === -1 || ability.uses > 0)
+        (!ability.maxUses || ability.maxUses === -1 || (ability.uses ?? 0) > 0)
     );
     bonusActions.push(...customBonusActions);
 
     return bonusActions;
   }
 
-  recoverHitDice(count) {
+  recoverHitDice(count: number): number {
     const maxHitDice = this.level;
     const diceToRecover = Math.min(count, maxHitDice - this.hitDiceRemaining);
     this.hitDiceRemaining += diceToRecover;
     return diceToRecover;
   }
 
-  hasRaft() {
+  hasRaft(): boolean {
     return this.inventory.some(item => item.effects && item.effects.allowsRiverCrossing === true);
   }
 
-  hasBoat() {
+  hasBoat(): boolean {
     return this.inventory.some(item => item.effects && item.effects.allowsWaterCrossing === true);
   }
 
-  canCrossTerrain(terrainKey) {
+  canCrossTerrain(terrainKey: string): boolean {
     if (terrainKey === 'river') {
       return this.hasRaft() || this.hasBoat();
     }
@@ -977,7 +1076,7 @@ export class Character {
     return true;
   }
 
-  increasePiety(amount = 1) {
+  increasePiety(amount = 1): number {
     this.hiddenStats.piety += amount;
     logger.items.info('Piety increased', {
       character: this.name,
@@ -987,7 +1086,7 @@ export class Character {
     return this.hiddenStats.piety;
   }
 
-  increaseGenerosity(goldOffered) {
+  increaseGenerosity(goldOffered: number) {
     if (goldOffered <= 0) {
       return { success: false, message: 'Offering must be greater than 0 gold' };
     }
@@ -1018,7 +1117,7 @@ export class Character {
     };
   }
 
-  initializeSpellSlots() {
+  initializeSpellSlots(): void {
     const casterClasses = [
       'Wizard',
       'Cleric',
@@ -1029,19 +1128,16 @@ export class Character {
       'Paladin',
       'Ranger',
     ];
-    if (casterClasses.includes(this.class)) {
+    if (this.class && casterClasses.includes(this.class)) {
       this.spellSlotsUsed = { 1: 0, 2: 0, 3: 0 };
     }
   }
 
   toJSON() {
-    const serializedEquipment = {};
-    Object.keys(this.equipment).forEach(slot => {
-      if (this.equipment[slot]) {
-        serializedEquipment[slot] = this.equipment[slot].toJSON();
-      } else {
-        serializedEquipment[slot] = null;
-      }
+    const serializedEquipment: Record<string, unknown> = {};
+    (Object.keys(this.equipment) as EquipmentSlot[]).forEach(slot => {
+      const item = this.equipment[slot];
+      serializedEquipment[slot] = item ? item.toJSON() : null;
     });
 
     const serializedInventory = this.inventory.map(item => (item.toJSON ? item.toJSON() : item));
@@ -1081,7 +1177,8 @@ export class Character {
     };
   }
 
-  static fromJSON(data) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static fromJSON(data: any): Character {
     const char = new Character(data.name, null);
     char.class = data.class;
     char.level = data.level;
@@ -1097,20 +1194,17 @@ export class Character {
     char.spells = [...data.spells];
     char.abilities_list = [...data.abilities_list];
 
-    char.equipment = {};
+    char.equipment = {} as Equipment;
     if (data.equipment) {
+      const eq = char.equipment as Record<string, Item | null>;
       Object.keys(data.equipment).forEach(slot => {
-        if (data.equipment[slot]) {
-          char.equipment[slot] = Item.fromJSON(data.equipment[slot]);
-        } else {
-          char.equipment[slot] = null;
-        }
+        eq[slot] = data.equipment[slot] ? Item.fromJSON(data.equipment[slot]) : null;
       });
     }
 
     char.inventory = [];
     if (data.inventory) {
-      char.inventory = data.inventory.map(itemData => Item.fromJSON(itemData));
+      char.inventory = data.inventory.map((itemData: ItemJSON) => Item.fromJSON(itemData));
     }
 
     char.gold = data.gold || 0;

--- a/src/game/DiceRoller.ts
+++ b/src/game/DiceRoller.ts
@@ -1,15 +1,53 @@
-// @ts-nocheck
-// TODO: Add proper types - DiceRoller D&D 5e dice rolling system
+// DiceRoller — D&D 5e dice rolling system
 import logger from '../utils/logger';
 
+type RollType = 'normal' | 'advantage' | 'disadvantage';
+type LogCallback = (message: string, type?: string) => void;
+
+/** Loose shape for the character objects passed into checks/attacks. */
+interface RollableCharacter {
+  proficiencyBonus?: number;
+  saveProficiencies?: string[];
+  abilities?: Record<string, number | undefined>;
+  [key: string]: unknown;
+}
+
+interface AdvantageRoll {
+  roll: number;
+  kept: number;
+  dropped: number;
+}
+
+interface CheckResult {
+  roll: number;
+  modifier: number;
+  total: number;
+  success: boolean;
+  dc: number;
+}
+
+interface AttackResult {
+  roll: number;
+  modifier: number;
+  total: number;
+  hit: boolean;
+  crit: boolean;
+  targetAC: number;
+  rollType: RollType;
+}
+
 export class DiceRoller {
-  constructor(seed = null, logger = null) {
+  seed: string | null;
+  rng: (() => number) | null;
+  logger: LogCallback | null;
+
+  constructor(seed: string | null = null, logCallback: LogCallback | null = null) {
     this.seed = seed;
     this.rng = seed !== null ? this.createSeededRNG(seed) : null;
-    this.logger = logger; // Optional callback function (message, type) => void
+    this.logger = logCallback; // Optional callback function (message, type) => void
   }
 
-  createSeededRNG(seed) {
+  createSeededRNG(seed: string): () => number {
     let seedValue = 0;
     for (let i = 0; i < seed.length; i++) {
       seedValue = (seedValue << 5) - seedValue + seed.charCodeAt(i);
@@ -22,21 +60,21 @@ export class DiceRoller {
     };
   }
 
-  random() {
+  random(): number {
     return this.rng ? this.rng() : Math.random();
   }
 
-  log(message, type = 'info') {
+  log(message: string, type = 'info'): void {
     if (this.logger) {
       this.logger(message, type);
     }
   }
 
-  rollD20() {
+  rollD20(): number {
     return Math.floor(this.random() * 20) + 1;
   }
 
-  rollDice(sides, count = 1) {
+  rollDice(sides: number, count = 1): number {
     let total = 0;
     for (let i = 0; i < count; i++) {
       total += Math.floor(this.random() * sides) + 1;
@@ -44,7 +82,7 @@ export class DiceRoller {
     return total;
   }
 
-  rollWithAdvantage() {
+  rollWithAdvantage(): AdvantageRoll {
     const roll1 = this.rollD20();
     const roll2 = this.rollD20();
     const kept = Math.max(roll1, roll2);
@@ -52,7 +90,7 @@ export class DiceRoller {
     return { roll: kept, kept, dropped };
   }
 
-  rollWithDisadvantage() {
+  rollWithDisadvantage(): AdvantageRoll {
     const roll1 = this.rollD20();
     const roll2 = this.rollD20();
     const kept = Math.min(roll1, roll2);
@@ -60,23 +98,23 @@ export class DiceRoller {
     return { roll: kept, kept, dropped };
   }
 
-  getAbilityModifier(abilityScore) {
+  getAbilityModifier(abilityScore: number): number {
     return Math.floor((abilityScore - 10) / 2);
   }
 
   skillCheck(
-    character,
-    ability,
+    character: RollableCharacter,
+    ability: string,
     proficient = false,
     dc = 10,
-    rollType = 'normal',
-    skillName = null
-  ) {
+    rollType: RollType = 'normal',
+    skillName: string | null = null
+  ): CheckResult {
     if (!character) {
       throw new Error('DiceRoller.skillCheck: character is required');
     }
 
-    const abilityScore = character[ability] || 10;
+    const abilityScore = (character[ability] as number | undefined) || 10;
     const modifier = this.getAbilityModifier(abilityScore);
     const proficiencyBonus = proficient ? character.proficiencyBonus || 2 : 0;
 
@@ -115,15 +153,24 @@ export class DiceRoller {
     };
   }
 
-  perceptionCheck(character, dc = 10, rollType = 'normal') {
+  perceptionCheck(character: RollableCharacter, dc = 10, rollType: RollType = 'normal'): CheckResult {
     return this.skillCheck(character, 'wisdom', true, dc, rollType, 'Perception');
   }
 
-  investigationCheck(character, dc = 10, rollType = 'normal') {
+  investigationCheck(
+    character: RollableCharacter,
+    dc = 10,
+    rollType: RollType = 'normal'
+  ): CheckResult {
     return this.skillCheck(character, 'intelligence', true, dc, rollType, 'Investigation');
   }
 
-  savingThrow(character, ability, dc = 10, rollType = 'normal') {
+  savingThrow(
+    character: RollableCharacter,
+    ability: string,
+    dc = 10,
+    rollType: RollType = 'normal'
+  ): CheckResult {
     if (!character) {
       throw new Error('DiceRoller.savingThrow: character is required');
     }
@@ -136,12 +183,12 @@ export class DiceRoller {
   }
 
   attackRoll(
-    character,
-    attackType = 'melee',
+    character: RollableCharacter,
+    attackType: 'melee' | 'ranged' = 'melee',
     targetAC = 10,
-    attackName = null,
-    rollType = 'normal'
-  ) {
+    attackName: string | null = null,
+    rollType: RollType = 'normal'
+  ): AttackResult {
     if (!character) {
       throw new Error('DiceRoller.attackRoll: character is required');
     }
@@ -202,16 +249,16 @@ export class DiceRoller {
     };
   }
 
-  damageRoll(diceString, damageType = null) {
+  damageRoll(diceString: string, damageType: string | null = null): number {
     const match = diceString.match(/(\d+)d(\d+)([+-]\d+)?/);
     if (!match) {
       logger.general.error('Invalid dice string', { diceString });
       return 0;
     }
 
-    const count = parseInt(match[1]);
-    const sides = parseInt(match[2]);
-    const bonus = match[3] ? parseInt(match[3]) : 0;
+    const count = parseInt(match[1], 10);
+    const sides = parseInt(match[2], 10);
+    const bonus = match[3] ? parseInt(match[3], 10) : 0;
 
     const damage = this.rollDice(sides, count) + bonus;
 

--- a/src/game/LineOfSight.ts
+++ b/src/game/LineOfSight.ts
@@ -1,17 +1,31 @@
-// @ts-nocheck
-// TODO: Add proper TypeScript types
 /**
  * LineOfSight - Line of sight calculation for hex grid
  * Uses Bresenham's line algorithm adapted for hexagonal grids
  */
 
+interface HexCoord {
+  col: number;
+  row: number;
+}
+
+interface CubeCoord {
+  x: number;
+  y: number;
+  z: number;
+}
+
+interface BattlefieldHex extends HexCoord {
+  blocked?: boolean;
+}
+
+interface Battlefield {
+  hexes: BattlefieldHex[];
+}
+
 /**
  * Convert offset coordinates to cube coordinates
- * @param {number} col - Column coordinate
- * @param {number} row - Row coordinate
- * @returns {Object} Cube coordinates {x, y, z}
  */
-export function offsetToCube(col, row) {
+export function offsetToCube(col: number, row: number): CubeCoord {
   const x = col - Math.floor(row / 2);
   const z = row;
   const y = -x - z;
@@ -20,12 +34,9 @@ export function offsetToCube(col, row) {
 
 /**
  * Convert cube coordinates to offset coordinates
- * @param {number} x - Cube X coordinate
- * @param {number} y - Cube Y coordinate (unused but kept for completeness)
- * @param {number} z - Cube Z coordinate
- * @returns {Object} Offset coordinates {col, row}
+ * (y is unused but kept for signature completeness)
  */
-export function cubeToOffset(x, y, z) {
+export function cubeToOffset(x: number, _y: number, z: number): HexCoord {
   const row = z;
   const col = x + Math.floor(z / 2);
   return { col, row };
@@ -33,12 +44,8 @@ export function cubeToOffset(x, y, z) {
 
 /**
  * Round fractional cube coordinates to nearest hex
- * @param {number} x - Fractional cube X
- * @param {number} y - Fractional cube Y
- * @param {number} z - Fractional cube Z
- * @returns {Object} Rounded cube coordinates {x, y, z}
  */
-function cubeRound(x, y, z) {
+function cubeRound(x: number, y: number, z: number): CubeCoord {
   let rx = Math.round(x);
   let ry = Math.round(y);
   let rz = Math.round(z);
@@ -60,22 +67,15 @@ function cubeRound(x, y, z) {
 
 /**
  * Linear interpolation between two values
- * @param {number} a - Start value
- * @param {number} b - End value
- * @param {number} t - Interpolation factor (0-1)
- * @returns {number} Interpolated value
  */
-function lerp(a, b, t) {
+function lerp(a: number, b: number, t: number): number {
   return a + (b - a) * t;
 }
 
 /**
  * Get all hexes on a line from start to end
- * @param {Object} from - Starting hex {col, row}
- * @param {Object} to - Ending hex {col, row}
- * @returns {Array} Array of hex positions [{col, row}, ...]
  */
-function getHexLine(from, to) {
+function getHexLine(from: HexCoord, to: HexCoord): HexCoord[] {
   const fromCube = offsetToCube(from.col, from.row);
   const toCube = offsetToCube(to.col, to.row);
 
@@ -92,7 +92,7 @@ function getHexLine(from, to) {
   }
 
   // Generate line
-  const results = [];
+  const results: HexCoord[] = [];
   for (let i = 0; i <= distance; i++) {
     const t = i / distance;
     const x = lerp(fromCube.x, toCube.x, t);
@@ -109,12 +109,8 @@ function getHexLine(from, to) {
 
 /**
  * Check if a target is in range using cube coordinate distance
- * @param {Object} from - Starting hex {col, row}
- * @param {Object} to - Target hex {col, row}
- * @param {number} range - Maximum range in hexes
- * @returns {boolean} True if target is in range
  */
-export function isInRange(from, to, range) {
+export function isInRange(from: HexCoord, to: HexCoord, range: number): boolean {
   const fromCube = offsetToCube(from.col, from.row);
   const toCube = offsetToCube(to.col, to.row);
 
@@ -129,17 +125,14 @@ export function isInRange(from, to, range) {
 }
 
 /**
- * Check line of sight between two hexes
- * @param {Object} from - Starting hex {col, row}
- * @param {Object} to - Target hex {col, row}
- * @param {Object} battlefield - Battlefield object with {hexes, width, height}
- * @returns {boolean} True if line of sight is clear, false if blocked
+ * Check line of sight between two hexes.
+ * Returns true if line of sight is clear, false if blocked.
  */
-export function checkLineOfSight(from, to, battlefield) {
+export function checkLineOfSight(from: HexCoord, to: HexCoord, battlefield: Battlefield): boolean {
   const { hexes } = battlefield;
 
   // Create hex lookup map
-  const hexMap = new Map();
+  const hexMap = new Map<string, BattlefieldHex>();
   hexes.forEach(hex => {
     hexMap.set(`${hex.col},${hex.row}`, hex);
   });

--- a/src/game/Spell.ts
+++ b/src/game/Spell.ts
@@ -1,9 +1,65 @@
-// @ts-nocheck
-// TODO: Add proper types - Spell class with effect functions
+// Spell — D&D 5e spell definition with an effect callback
 import logger from '../utils/logger';
 
+interface SpellComponents {
+  verbal: boolean;
+  somatic: boolean;
+  material: boolean;
+}
+
+/** Loose shape for a spellcaster (Character / Enemy). */
+interface SpellCaster {
+  name?: string;
+  class?: string;
+  proficiencyBonus?: number;
+  abilities?: Record<string, number | undefined>;
+  [key: string]: unknown;
+}
+
+type SpellEffect = (
+  caster: SpellCaster,
+  target: unknown,
+  diceRoller: unknown
+) => Record<string, unknown>;
+
+interface CastResult {
+  success: boolean;
+  message?: string;
+  [key: string]: unknown;
+}
+
+export interface SpellConfig {
+  name: string;
+  level: number;
+  school: string;
+  castingTime?: string;
+  range?: string;
+  components?: SpellComponents;
+  duration?: string;
+  concentration?: boolean;
+  targetType?: string;
+  savingThrow?: string | null;
+  attackRoll?: boolean;
+  effect?: SpellEffect;
+  description?: string;
+}
+
 export class Spell {
-  constructor(config) {
+  name: string;
+  level: number;
+  school: string;
+  castingTime: string;
+  range: string;
+  components: SpellComponents;
+  duration: string;
+  concentration: boolean;
+  targetType: string;
+  savingThrow: string | null;
+  attackRoll: boolean;
+  effect?: SpellEffect;
+  description: string;
+
+  constructor(config: SpellConfig) {
     this.name = config.name;
     this.level = config.level;
     this.school = config.school;
@@ -19,7 +75,7 @@ export class Spell {
     this.description = config.description || '';
   }
 
-  cast(caster, target, diceRoller) {
+  cast(caster: SpellCaster, target: unknown, diceRoller: unknown): CastResult {
     if (!this.effect) {
       return { success: false, message: `${this.name} has no effect defined` };
     }
@@ -28,30 +84,31 @@ export class Spell {
       const result = this.effect(caster, target, diceRoller);
       return { success: true, ...result };
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       logger.combat.error('Error casting spell', {
         spell: this.name,
-        error: error.message,
+        error: message,
         caster: caster.name,
       });
-      return { success: false, message: `Failed to cast ${this.name}: ${error.message}` };
+      return { success: false, message: `Failed to cast ${this.name}: ${message}` };
     }
   }
 
-  getSpellSaveDC(caster) {
-    const spellcastingAbility = this._getSpellcastingAbility(caster.class);
-    const abilityMod = this._getAbilityModifier(caster.abilities[spellcastingAbility]);
+  getSpellSaveDC(caster: SpellCaster): number {
+    const spellcastingAbility = this._getSpellcastingAbility(caster.class ?? '');
+    const abilityMod = this._getAbilityModifier(caster.abilities?.[spellcastingAbility] ?? 10);
     return 8 + (caster.proficiencyBonus || 2) + abilityMod;
   }
 
-  getSpellAttackBonus(caster) {
-    const spellcastingAbility = this._getSpellcastingAbility(caster.class);
-    const abilityMod = this._getAbilityModifier(caster.abilities[spellcastingAbility]);
+  getSpellAttackBonus(caster: SpellCaster): number {
+    const spellcastingAbility = this._getSpellcastingAbility(caster.class ?? '');
+    const abilityMod = this._getAbilityModifier(caster.abilities?.[spellcastingAbility] ?? 10);
     return (caster.proficiencyBonus || 2) + abilityMod;
   }
 
-  _getSpellcastingAbility(className) {
+  _getSpellcastingAbility(className: string): string {
     const classKey = className.toLowerCase();
-    const spellcastingAbilities = {
+    const spellcastingAbilities: Record<string, string> = {
       wizard: 'intelligence',
       sorcerer: 'charisma',
       warlock: 'charisma',
@@ -64,7 +121,7 @@ export class Spell {
     return spellcastingAbilities[classKey] || 'intelligence';
   }
 
-  _getAbilityModifier(abilityScore) {
+  _getAbilityModifier(abilityScore: number): number {
     return Math.floor((abilityScore - 10) / 2);
   }
 

--- a/tests/contexts/reducers/inventoryReducer.test.ts
+++ b/tests/contexts/reducers/inventoryReducer.test.ts
@@ -201,7 +201,8 @@ describe('inventoryReducer — UNEQUIP_ITEM', () => {
       ACTIONS
     );
     const char = result?.playerCharacter as any;
-    expect(char.equipment.offHand).toBeUndefined();
+    // Empty slots are represented as null (matches Character.unequipItem and toJSON), not deleted.
+    expect(char.equipment.offHand).toBeNull();
     expect(char.inventory.some((i: any) => i.id === 'shield-1')).toBe(true);
   });
 


### PR DESCRIPTION
@
## Summary

First batch of TODO #1 (remove `// @ts-nocheck` suppressions), starting with the smallest pure leaf modules and then the keystone `Character` class. **No runtime logic changes beyond the explicit bug fixes below — this is type annotation work**, verified by `tsc` and the unit suite.

Typed (and removed `@ts-nocheck` from):
- **`DiceRoller.ts`** — `RollType`/`LogCallback`/result interfaces, typed `RollableCharacter` param
- **`LineOfSight.ts`** — `HexCoord`/`CubeCoord`/`Battlefield` interfaces across all helpers
- **`Spell.ts`** — `SpellConfig`/`SpellCaster`/`CastResult` interfaces, narrowed `catch` error
- **`Character.ts`** (1145 lines) — full field declarations + every method signature

## Bugs surfaced by typing `Character`

Typing `Character` made its fields visible to the already-checked reducers, which exposed three genuine latent bugs:

1. **`gainXP` → `awardXP`** — `combatReducer`, `explorationReducer`, and `questReducer` all called `Character.gainXP()`, which **does not exist**. This was a `TypeError` waiting to fire on every XP award (combat victory, encounter clear, quest turn-in). The real method is `awardXP()`. (`combatReducer` still has `@ts-nocheck`, so its copy of the bug was invisible to the compiler — fixed anyway.)
2. **Dead `CONSUME_WATER` reducer case removed** — it referenced `character.water`, a field that no longer exists (water survival was deprecated; only rations remain). The never-dispatched `FIND_WATER` case was removed alongside it.
3. **Missing `logger` import in `inventoryReducer`** — `EQUIP_ITEM`s not-found branch referenced `logger` with no import (latent `ReferenceError`).

Also: `UNEQUIP_ITEM` now sets the slot to `null` instead of `delete`-ing it, matching `Character.unequipItem()`/`toJSON()` (empty slots are `null` everywhere else). Updated the one test that asserted the old `delete`/`undefined` behavior.

## Impact
- **Typecheck: 22 pre-existing errors → 0.** (The 22 were Character-field accesses leaking into typed reducers.)
- `@ts-nocheck` file count: 100 → 96
- All **269** unit tests pass; `npm run build` succeeds.

## Note (out of scope)
`npm run lint` is currently broken project-wide — ESLint v9 is installed but only a legacy `.eslintrc.cjs` exists (needs flat-config migration). Pre-existing, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@